### PR TITLE
Prevenir erro caso nome de produto muito extenso

### DIFF
--- a/moloni/src/Tools.php
+++ b/moloni/src/Tools.php
@@ -33,7 +33,7 @@ class Tools
             $reference .= '_' . $variationId;
         }
 
-        return $reference;
+        return mb_substr($reference, 0, 30);
     }
 
     /**


### PR DESCRIPTION
Previne o erro "Erro ao inserir o artigo " caso a referência do artigo seja superior a 30 caracteres que é o limite que teem no vosso backoffice.