### PR TITLE
Melhoramento de Referência Gerada

### DIFF
--- a/moloni/src/Controllers/Product.php
+++ b/moloni/src/Controllers/Product.php
@@ -151,7 +151,7 @@ class Product
         $this->reference = $this->product->get_sku();
 
         if (empty($this->reference)) {
-            $this->reference = Tools::createReferenceFromString($this->product->get_name());
+            $this->reference = Tools::createReferenceFromString($this->product->get_name(), $this->product->get_id());
         }
 
         return $this;

--- a/moloni/src/Tools.php
+++ b/moloni/src/Tools.php
@@ -21,16 +21,16 @@ class Tools
         $reference = '';
         $name = explode(' ', $string);
 
-        foreach ($name as $word) {
-            $reference .= '_' . mb_substr($word, 0, 3);
-        }
-
         if ((int)$productId > 0) {
             $reference .= '_' . $productId;
         }
 
         if ((int)$variationId > 0) {
             $reference .= '_' . $variationId;
+        }
+
+        foreach ($name as $word) {
+            $reference .= '_' . mb_substr($word, 0, 3);
         }
 
         return mb_substr($reference, 0, 30);


### PR DESCRIPTION
Melhorar referência gerada com ProdutoID_VariationID_ProductName.

Prevenindo o erro de referência deve ser unica ao gerar fatura em casos de produtos com nomes similares compridos, dado à limitação de 30 caracteres na referência do Moloni.