### PR TITLE
Sugestão: Remoção do nome do produto da referência

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -19,7 +19,6 @@ class Tools
     public static function createReferenceFromString($string, $productId = 0, $variationId = 0)
     {
         $reference = '';
-        $name = explode(' ', $string);
 
         if ((int)$productId > 0) {
             $reference .= '_' . $productId;
@@ -27,10 +26,6 @@ class Tools
 
         if ((int)$variationId > 0) {
             $reference .= '_' . $variationId;
-        }
-
-        foreach ($name as $word) {
-            $reference .= '_' . mb_substr($word, 0, 3);
         }
 
         return mb_substr($reference, 0, 30);


### PR DESCRIPTION
Gostaria de sugerir a remoção do nome do produto compilado da referência pois tem nos criado vários problemas quando efectuam alterações num nome de produto no site principalmente em nomes compridos em que ao tentar gerar fatura no moloni através deste plugin muitas vezes retorna erro a informar que "reference must be unique".

Para resolver sugiro a remoção do nome mantendo apenas o Id do Produto e caso tenha variação o id da variação. 
Isto não causa problemas a clientes existentes uma vez que as próximas faturas vai gerar os produtos apenas através do id do site.

Para prevenir que este id já exista no moloni manualmente criado sugiro criar um prefixo a esta função createReferenceFromString como por exemplo "woo" de woocomerce ficando algo como "woo_132456" como referencia de produto no moloni.

Estou disposto a criar um PR com o prefixo caso aceitem este.