### PR TITLE
Remove HTML tags

### DIFF
--- a/src/Controllers/Payment.php
+++ b/src/Controllers/Payment.php
@@ -31,7 +31,7 @@ class Payment
      */
     public function __construct($name)
     {
-        $this->name = trim($name);
+        $this->name = strip_tags(trim($name));
     }
 
     /**


### PR DESCRIPTION
## Description  
Some payment method names included HTML image tags, causing images to appear in document PDFs.  
This update ensures HTML tags are properly removed from payment method names before rendering,  
so only clean text is displayed.

## Changes  
- Removed HTML tags from payment method names before generating PDFs.

## Testing  
- [x] Tested orders with payment methods **without** HTML in names  
- [x] Tested orders with payment methods **with** HTML in names  
- [x] Tested orders **without** payment methods

## Checklist  
- [x] Tested on a WordPress site  
- [x] Verified compliance with WordPress coding standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation to remove HTML tags from user-submitted data, improving data integrity and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->